### PR TITLE
Sanitize search queries

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 helix-importer-ui
 blocks/embed/lite-yt-embed.js
+tools/importer

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -50,6 +50,8 @@ function formatSearchResultCount(num, placeholders, term, lang) {
 }
 
 async function searchPages(placeholders, term, page) {
+  // Remove characters that could be a tag to avoid injection.
+  const saniterm = term.replace('<', '').replace('>', '');
   const sheet = `${getLanguage()}-search`;
 
   const json = await fetchIndex('query-index', sheet);
@@ -60,13 +62,13 @@ async function searchPages(placeholders, term, page) {
 
   const result = json.data
     .filter((entry) => `${entry.description} ${entry.pagename} ${entry.breadcrumbtitle} ${entry.title}`.toLowerCase()
-      .includes(term.toLowerCase()));
+      .includes(saniterm.toLowerCase()));
 
   const div = document.createElement('div');
 
   const summary = document.createElement('h3');
   summary.classList.add('search-summary');
-  summary.innerHTML = formatSearchResultCount(result.length, placeholders, term, getLanguage());
+  summary.innerHTML = formatSearchResultCount(result.length, placeholders, saniterm, getLanguage());
   div.appendChild(summary);
 
   const curPage = result.slice(startResult, startResult + resultsPerPage);
@@ -77,7 +79,7 @@ async function searchPages(placeholders, term, page) {
     const header = document.createElement('h3');
     const link = document.createElement('a');
     const searchTitle = line.pagename || line.breadcrumbtitle || line.title;
-    setResultValue(link, searchTitle, term);
+    setResultValue(link, searchTitle, saniterm);
     link.href = line.path;
     const path = line.path || '';
     const parentPath = path && path.lastIndexOf('/') > -1 ? path.slice(0, path.lastIndexOf('/')) : '';
@@ -131,7 +133,7 @@ async function searchPages(placeholders, term, page) {
     header.appendChild(link);
     res.appendChild(header);
     const para = document.createElement('p');
-    setResultValue(para, line.description, term);
+    setResultValue(para, line.description, saniterm);
 
     res.appendChild(para);
     div.appendChild(res);

--- a/test/blocks/search-results/search-results.test.js
+++ b/test/blocks/search-results/search-results.test.js
@@ -67,7 +67,7 @@ describe('Search Results', () => {
 
     const block = document.querySelector('.search-results');
     const loc = {
-      search: '?s=tex',
+      search: '?s=<t>ex',
       pathname: '/search',
     };
 


### PR DESCRIPTION
Sanitize the search query before executing the search.

Test URLs:
- Before: https://main--sunstar-engineering--sunstar-engineering.hlx.page/search?s=adhes
- After: https://sanitizehtml--sunstar-engineering--sunstar-engineering.hlx.page/search?s=adhes

Also removed `tools/importer` from the resources fed through eslint as its current state on main causes many failures which prevents commits.