### PR TITLE
Add hreflang alternatives to sitemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ npm run lint
 1. Install the [Helix CLI](https://github.com/adobe/helix-cli): `npm install -g @adobe/helix-cli`
 1. Start Franklin Proxy: `hlx up` (opens your browser at `http://localhost:3000`)
 1. Open the `{repo}` directory in your favorite IDE and start coding :)
+

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -6,7 +6,6 @@ sitemaps:
     lastmod: YYYY-MM-DD
     languages:
       en:
-        origin: https://www.sunstar-engineering.com
         source: /query-index.json?sheet=en-search
         destination: /sitemap-en.xml
         hreflang: en

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,8 +1,41 @@
 version: 1
 auto-generated: true
 sitemaps:
-  default:
-    origin: https://www.sunstar-engineering.com
-    source: /query-index.json
-    destination: /sitemap.xml
+  sunstar-engineering:
+    default: en
     lastmod: YYYY-MM-DD
+    languages:
+      en:
+        source: /query-index.json?sheet=en-search
+        destination: /sitemap-en.xml
+        hreflang: en
+      cn:
+        source: /query-index.json?sheet=cn-search
+        destination: /sitemap-cn.xml
+        hreflang: cn
+        alternate: /cn/{path}
+      th:
+        source: /query-index.json?sheet=th-search
+        destination: /sitemap-th.xml
+        hreflang: th
+        alternate: /th/{path}
+      it:
+        source: /query-index.json?sheet=it-search
+        destination: /sitemap-it.xml
+        hreflang: it
+        alternate: /it/{path}
+      ja:
+        source: /query-index.json?sheet=ja-search
+        destination: /sitemap-ja.xml
+        hreflang: ja
+        alternate: /ja/{path}
+      id:
+        source: /query-index.json?sheet=id-search
+        destination: /sitemap-id.xml
+        hreflang: id
+        alternate: /id/{path}
+      de:
+        source: /query-index.json?sheet=de-search
+        destination: /sitemap-de.xml
+        hreflang: de
+        alternate: /de/{path}

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -6,6 +6,7 @@ sitemaps:
     lastmod: YYYY-MM-DD
     languages:
       en:
+        origin: https://www.sunstar-engineering.com
         source: /query-index.json?sheet=en-search
         destination: /sitemap-en.xml
         hreflang: en

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.sunstar-engineering.com/sitemap.xml
+Sitemap: https://www.sunstar-engineering.com/sitemap-index.xml

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-en.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-cn.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-th.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-it.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-ja.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-id.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-de.xml</loc>
+    </sitemap>
+</sitemapindex>


### PR DESCRIPTION
There are now 7 sitemaps: sitemap-en.xml, sitemap-cn.xml, sitemap-th.xml, sitemap-it.xml, sitemap-ja.xml, sitemap-id.xml and sitemap-de.xml for the 7 languages. They are referenced into robots.txt via the new sitemap-index.xml

A sample of a generated sitemap looks like this:

```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>https://www.sunstar-engineering.com/th/terms</loc>
    <lastmod>2023-07-27</lastmod>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar-engineering.com/terms"/>
    <xhtml:link rel="alternate" hreflang="cn" href="https://www.sunstar-engineering.com/cn/terms"/>
    <xhtml:link rel="alternate" hreflang="th" href="https://www.sunstar-engineering.com/th/terms"/>
    <xhtml:link rel="alternate" hreflang="it" href="https://www.sunstar-engineering.com/it/terms"/>
    <xhtml:link rel="alternate" hreflang="ja" href="https://www.sunstar-engineering.com/ja/terms"/>
    <xhtml:link rel="alternate" hreflang="id" href="https://www.sunstar-engineering.com/id/terms"/>
    <xhtml:link rel="alternate" hreflang="de" href="https://www.sunstar-engineering.com/de/terms"/>
    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.sunstar-engineering.com/terms"/>
  </url>
  <url>
    <loc>https://www.sunstar-engineering.com/th/privacy</loc>
    <lastmod>2023-07-27</lastmod>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar-engineering.com/privacy"/>
    <xhtml:link rel="alternate" hreflang="cn" href="https://www.sunstar-engineering.com/cn/privacy"/>
    <xhtml:link rel="alternate" hreflang="th" href="https://www.sunstar-engineering.com/th/privacy"/>
    ...
```

Fixes: #19

The new sitemaps can be found here:
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-en.xml
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-cn.xml
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-th.xml
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-it.xml
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-ja.xml
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-id.xml
* https://hreflang--sunstar-engineering--bosschaert.hlx.live/sitemap-de.xml

